### PR TITLE
fix: use LogDNA github repo 0.1.0 tag to find python lambda code

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -25,5 +25,5 @@ variable "service_identifier" {
 
 variable "url" {
   description = "URL to script content. Defaults to GitHub Master"
-  default     = "https://raw.githubusercontent.com/logdna/aws-cloudwatch/master/python/logdna_cloudwatch.py"
+  default     = "https://raw.githubusercontent.com/logdna/aws-cloudwatch/0.1.0/logdna_cloudwatch.py"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,5 +25,5 @@ variable "service_identifier" {
 
 variable "url" {
   description = "URL to script content. Defaults to GitHub Master"
-  default     = "https://raw.githubusercontent.com/logdna/aws-cloudwatch/master/logdna_cloudwatch.py"
+  default     = "https://raw.githubusercontent.com/logdna/aws-cloudwatch/master/python/logdna_cloudwatch.py"
 }


### PR DESCRIPTION
LogDNA removed the python code for the CloudWatch -> LogDNA lambda from their GitHub repo, so I changed the URL to an old tag to access it again.

A future PR could switch this to their new Node lambda.