### PR TITLE
Fix drift detection with full path vs relative path for package.zip

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,16 @@
+locals {
+  output_file        = "${data.null_data_source.lambda_file.outputs.filename}"
+  service_identifier = "${var.service_identifier}"
+  logdna_tags        = "${join(",", concat(list(data.aws_region.current.name), var.logdna_tags))}"
+  environment        = "${map("LOGDNA_KEY", "${var.logdna_key}", "LOGDNA_TAGS", "${local.logdna_tags}")}"
+}
+
+data "null_data_source" "lambda_file" {
+  inputs {
+    filename = "${substr("${path.module}/files/lambda/package.zip", length(path.cwd) + 1, -1)}"
+  }
+}
+
 data "http" "logdna_cloudwatch" {
   url = "${var.url}"
 }
@@ -24,13 +37,6 @@ data "aws_iam_policy_document" "lambda_execution_role" {
 }
 
 data "aws_region" "current" {}
-
-locals {
-  output_file        = "${path.module}/files/lambda/package.zip"
-  service_identifier = "${var.service_identifier}"
-  logdna_tags        = "${join(",", concat(list(data.aws_region.current.name), var.logdna_tags))}"
-  environment        = "${map("LOGDNA_KEY", "${var.logdna_key}", "LOGDNA_TAGS", "${local.logdna_tags}")}"
-}
 
 resource "aws_iam_role" "lambda_execution_role" {
   name_prefix        = "lambda.${local.service_identifier}."


### PR DESCRIPTION
Simple change, and nothing really functionally different. This just means that in `terraform plan` output, we only see actual differences and not the constantly changing full path stored within the Terraform state.